### PR TITLE
Create `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Generated directories
+
+/build
+/data


### PR DESCRIPTION
The `.gitignore` file tell Git what files it must not commit.

Adding files that are not wanted in a Git repo like compiled executables to a `.gitignore` will keep this repo tidy and will prevent accidental commits including these files.